### PR TITLE
Add separate EMA and ADX feature handling

### DIFF
--- a/bybitbot/bot.py
+++ b/bybitbot/bot.py
@@ -213,6 +213,8 @@ class TradingBot:
             required.append("sma")
         if "ema" in self.indicators:
             df["ema"] = ta.ema(df["close"], length=10)
+            required.append("ema")
+        if "adx" in self.indicators:
             adx = ta.adx(df["high"], df["low"], df["close"], length=14)
             df["adx"] = adx["ADX_14"]
             required.append("adx")
@@ -408,8 +410,6 @@ class TradingBot:
             tp=price * (1 - self.tp_percent / 100),
             sl=price * (1 + self.sl_percent / 100),
         )
-        filled = order.get("filledQty", qty) if order else qty
-         )
         filled = order.get("filledQty", qty) if order else qty
         self.position_price = price
         self.position_amount = -filled

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,5 @@
+import sys
+from pathlib import Path
+
+# Ensure project root is on sys.path
+sys.path.append(str(Path(__file__).resolve().parents[1]))

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -18,6 +18,40 @@ def test_compute_features_shape():
     assert features is not None
     assert features.shape == (1, len(features.flatten()))
 
+
+def test_ema_indicator():
+    data = {
+        "close": list(range(1, 61)),
+        "high": [x + 0.5 for x in range(1, 61)],
+        "low": [x - 0.5 for x in range(1, 61)],
+        "volume": [1] * 60,
+        "bid_qty": [1] * 60,
+        "ask_qty": [1] * 60,
+    }
+    df = pd.DataFrame(data)
+    bot = TradingBot()
+    bot.indicators = ["ema"]
+    feats = bot.compute_features(df)
+    assert feats is not None
+    assert feats.shape == (1, 3)
+
+
+def test_adx_indicator():
+    data = {
+        "close": list(range(1, 61)),
+        "high": [x + 0.5 for x in range(1, 61)],
+        "low": [x - 0.5 for x in range(1, 61)],
+        "volume": [1] * 60,
+        "bid_qty": [1] * 60,
+        "ask_qty": [1] * 60,
+    }
+    df = pd.DataFrame(data)
+    bot = TradingBot()
+    bot.indicators = ["adx"]
+    feats = bot.compute_features(df)
+    assert feats is not None
+    assert feats.shape == (1, 3)
+
 def test_bid_ask_zero_division():
     data = {
         "close": [1, 2],


### PR DESCRIPTION
## Summary
- Split EMA and ADX indicator logic so each is computed only when requested
- Add tests for EMA and ADX feature generation
- Ensure tests can import project package via conftest

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a46a455ad8832ba007fc08ccb6d439