### PR TITLE
Add timeout handling to Telegram messaging

### DIFF
--- a/bybitbot/bot.py
+++ b/bybitbot/bot.py
@@ -149,7 +149,7 @@ class TradingBot:
             self.model_initialized = False
 
     # ------------------------------------------------------------------
-    def send_telegram(self, msg: str) -> None:
+    def send_telegram(self, msg: str, timeout: int = 5) -> None:
         """Send message to telegram if credentials configured."""
         if not self.telegram_token or not self.telegram_chat_id:
             return
@@ -157,8 +157,11 @@ class TradingBot:
             requests.post(
                 f"https://api.telegram.org/bot{self.telegram_token}/sendMessage",
                 data={"chat_id": self.telegram_chat_id, "text": msg},
+                timeout=timeout,
             )
-        except Exception as exc:  # pragma: no cover - network issues
+        except requests.Timeout:
+            logging.warning("Telegram send timeout")
+        except requests.RequestException as exc:  # pragma: no cover - network issues
             logging.warning("Telegram error: %s", exc)
 
     def fetch_news_sentiment(self) -> float:
@@ -408,8 +411,6 @@ class TradingBot:
             tp=price * (1 - self.tp_percent / 100),
             sl=price * (1 + self.sl_percent / 100),
         )
-        filled = order.get("filledQty", qty) if order else qty
-         )
         filled = order.get("filledQty", qty) if order else qty
         self.position_price = price
         self.position_amount = -filled

--- a/tests/test_telegram.py
+++ b/tests/test_telegram.py
@@ -1,0 +1,24 @@
+import logging
+import requests
+
+from bybitbot import TradingBot
+
+
+def test_send_telegram_timeout(monkeypatch, caplog):
+    bot = TradingBot()
+    bot.telegram_token = "token"
+    bot.telegram_chat_id = "chat"
+
+    captured = {}
+
+    def fake_post(url, data=None, timeout=None):
+        captured["timeout"] = timeout
+        raise requests.Timeout
+
+    monkeypatch.setattr(requests, "post", fake_post)
+
+    with caplog.at_level(logging.WARNING):
+        bot.send_telegram("hi")
+
+    assert captured["timeout"] == 5
+    assert "Telegram send timeout" in caplog.text


### PR DESCRIPTION
## Summary
- add configurable timeout to `send_telegram`
- log and continue when Telegram requests time out
- cover timeout behavior with new unit test

## Testing
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a46a455c84832b81453f839115a83d