### PR TITLE
Fix open_short function and add unit test

### DIFF
--- a/bybitbot/bot.py
+++ b/bybitbot/bot.py
@@ -409,8 +409,6 @@ class TradingBot:
             sl=price * (1 + self.sl_percent / 100),
         )
         filled = order.get("filledQty", qty) if order else qty
-         )
-        filled = order.get("filledQty", qty) if order else qty
         self.position_price = price
         self.position_amount = -filled
         self.trailing_price = (

--- a/tests/test_open_short.py
+++ b/tests/test_open_short.py
@@ -1,0 +1,23 @@
+from bybitbot import TradingBot
+
+
+def test_open_short(tmp_path):
+    bot = TradingBot()
+    bot.trade_file = tmp_path / "trades.csv"
+    messages = []
+    bot.place_order = lambda side, qty, tp=None, sl=None: {"filledQty": qty}
+    bot.send_telegram = lambda msg: messages.append(msg)
+    bot.trailing_percent = 1.0
+    bot.qty_step = 0.01
+    expected_qty = bot._round_qty(bot.compute_trade_amount() / 100.0)
+    bot.open_short(100.0)
+    assert bot.position_price == 100.0
+    assert bot.position_amount == -expected_qty
+    assert bot.trailing_price == 101.0
+    assert messages and "Opened short" in messages[0]
+    lines = bot.trade_file.read_text().strip().splitlines()
+    assert lines[0] == "time,side,price,qty,pnl,tp,sl"
+    row = lines[1].split(",")
+    assert row[1] == "sell"
+    assert float(row[2]) == 100.0
+    assert float(row[3]) == expected_qty


### PR DESCRIPTION
## Summary
- remove duplicated lines in `open_short`
- add test for opening short positions

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a46a446e34832b846cde5ccdb6a0c4