### PR TITLE
Reset training state on indicator change and validate features

### DIFF
--- a/bybitbot/bot.py
+++ b/bybitbot/bot.py
@@ -54,7 +54,7 @@ class TradingBot:
         self.model_save_interval = int(os.getenv("MODEL_SAVE_INTERVAL", 10))
         self.daily_loss_limit = float(os.getenv("DAILY_STOP_LOSS", 0))
         self.daily_profit_limit = float(os.getenv("DAILY_TAKE_PROFIT", 0))
-        self.indicators: List[str] = self.config.get(
+        self._indicators: List[str] = self.config.get(
             "indicators",
             ["rsi", "macd", "bb", "sma", "ema", "adx", "stoch", "obv"],
         )
@@ -95,6 +95,17 @@ class TradingBot:
 
         self.long_threshold = float(os.getenv("LONG_THRESHOLD", 0.55))
         self.short_threshold = float(os.getenv("SHORT_THRESHOLD", 0.45))
+
+    @property
+    def indicators(self) -> List[str]:
+        return self._indicators
+
+    @indicators.setter
+    def indicators(self, value: List[str]) -> None:
+        self._indicators = value
+        self.features_list.clear()
+        self.labels_list.clear()
+        self.scaler = StandardScaler()
 
     @staticmethod
     def _load_config(path: str) -> dict:
@@ -238,6 +249,28 @@ class TradingBot:
         if "news" in self.indicators:
             df["sentiment"] = self.fetch_news_sentiment()
             required.append("sentiment")
+        feature_counts = {
+            "rsi": 1,
+            "macd": 1,
+            "bb": 2,
+            "sma": 1,
+            "ema": 1,
+            "adx": 1,
+            "stoch": 2,
+            "obv": 1,
+            "news": 1,
+        }
+        expected = 1
+        for ind in self.indicators:
+            if ind not in feature_counts:
+                logging.warning("Unknown indicator: %s", ind)
+                return None
+            expected += feature_counts[ind]
+        if len(required) != expected:
+            logging.warning(
+                "Indicator feature mismatch: expected %d, got %d", expected, len(required)
+            )
+            return None
         row = df.iloc[-1]
         if row[required].isna().any():
             return None

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -84,7 +84,7 @@ def _make_dataframe(size: int = 60) -> pd.DataFrame:
 
 @pytest.mark.parametrize(
     "inds, expected_len, has_news",
-    [(["ema"], 3, False), (["ema", "news"], 4, True), (["ema", "adx", "news"], 4, True)],
+    [(["ema"], 3, False), (["ema", "news"], 4, True), (["ema", "adx", "news"], 5, True)],
 )
 def test_compute_features_combinations(inds, expected_len, has_news, monkeypatch):
     df = _make_dataframe()
@@ -95,4 +95,4 @@ def test_compute_features_combinations(inds, expected_len, has_news, monkeypatch
     assert feats is not None
     assert feats.shape == (1, expected_len)
     if has_news:
-        assert feats[0, 2] == 0.5
+        assert feats[0, -2] == 0.5

--- a/tests/test_indicator_change.py
+++ b/tests/test_indicator_change.py
@@ -1,0 +1,14 @@
+from bybitbot import TradingBot
+
+
+def test_training_continues_after_indicator_change():
+    bot = TradingBot()
+    bot.history_len = 10
+    bot.indicators = ["ema"]
+    for i in range(11):
+        bot.update_model(i + 1, i + 1.5, i + 0.5, 1, 1, 1)
+    assert len(bot.features_list) > 0
+    bot.indicators = ["ema", "sma"]
+    assert len(bot.features_list) == 0
+    result = bot.update_model(12, 12.5, 11.5, 1, 1, 1)
+    assert result is not None


### PR DESCRIPTION
## Summary
- reset features, labels and scaler whenever the indicator set is modified
- ensure compute_features validates expected feature count and warns on mismatch
- add test confirming model training continues after changing indicators

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a46f4b36b0832b8556ad941018f901