### PR TITLE
Refactor trade cycle to asyncio

### DIFF
--- a/bybitbot/bot.py
+++ b/bybitbot/bot.py
@@ -1,6 +1,7 @@
 import os
 import time
 import logging
+import asyncio
 from typing import List, Optional
 
 import joblib
@@ -498,7 +499,7 @@ class TradingBot:
         self.daily_pnl += profit
 
     # ------------------------------------------------------------------
-    def trade_cycle(self, max_iterations: Optional[int] = None) -> None:
+    async def trade_cycle(self, max_iterations: Optional[int] = None) -> None:
         use_websocket = os.getenv("USE_WEBSOCKET", "0") == "1"
         if use_websocket:
             from pybit.unified_trading import WebSocket
@@ -568,10 +569,14 @@ class TradingBot:
                     bid = self.last_bid_qty
                     ask = self.last_ask_qty
                 else:
-                    price, high, low, vol, bid, ask = self.get_market_data()
-                features = self.update_model(price, high, low, vol, bid, ask)
+                    price, high, low, vol, bid, ask = await asyncio.to_thread(
+                        self.get_market_data
+                    )
+                features = await asyncio.to_thread(
+                    self.update_model, price, high, low, vol, bid, ask
+                )
                 if features is None:
-                    time.sleep(self.interval)
+                    await asyncio.sleep(self.interval)
                     continue
                 prob = self.model.predict_proba(features)[0][1]
 
@@ -596,10 +601,13 @@ class TradingBot:
                         self.open_long(price)
                     elif prob < self.short_threshold:
                         self.open_short(price)
-                time.sleep(self.interval)
+                await asyncio.sleep(self.interval)
                 iteration += 1
                 if max_iterations is not None and iteration >= max_iterations:
                     break
+        except asyncio.CancelledError:
+            logging.info("Trading loop cancelled")
+            raise
         except KeyboardInterrupt:
             logging.info("Trading loop interrupted by user")
         except Exception as exc:
@@ -608,4 +616,4 @@ class TradingBot:
 
 if __name__ == "__main__":
     bot = TradingBot()
-    bot.trade_cycle()
+    asyncio.run(bot.trade_cycle())

--- a/main.py
+++ b/main.py
@@ -1,6 +1,7 @@
 from bybitbot import TradingBot
+import asyncio
 
 
 if __name__ == "__main__":
     bot = TradingBot()
-    bot.trade_cycle()
+    asyncio.run(bot.trade_cycle())

--- a/tests/test_daily_limits.py
+++ b/tests/test_daily_limits.py
@@ -1,6 +1,7 @@
 import pytest
 
 from bybitbot import TradingBot
+import asyncio
 
 
 def test_daily_loss_limit_stops_trading(monkeypatch):
@@ -11,7 +12,7 @@ def test_daily_loss_limit_stops_trading(monkeypatch):
     bot.update_pnl(-50)  # total -120 <= -100
     monkeypatch.setattr(bot, "get_market_data", lambda: pytest.fail("should not fetch data"))
     monkeypatch.setattr(bot, "update_model", lambda *a, **k: pytest.fail("should not update model"))
-    bot.trade_cycle(max_iterations=1)
+    asyncio.run(bot.trade_cycle(max_iterations=1))
 
 
 def test_daily_profit_limit_stops_trading(monkeypatch):
@@ -21,5 +22,5 @@ def test_daily_profit_limit_stops_trading(monkeypatch):
     bot.update_pnl(50)  # total 110 >= 100
     monkeypatch.setattr(bot, "get_market_data", lambda: pytest.fail("should not fetch data"))
     monkeypatch.setattr(bot, "update_model", lambda *a, **k: pytest.fail("should not update model"))
-    bot.trade_cycle(max_iterations=1)
+    asyncio.run(bot.trade_cycle(max_iterations=1))
 


### PR DESCRIPTION
## Summary
- Convert `trade_cycle` to an async function using `asyncio`
- Replace `time.sleep` with `asyncio.sleep` and run blocking operations via `asyncio.to_thread`
- Run the bot with `asyncio.run` in `main.py` and tests

## Testing
- `pytest` *(fails: test_compute_features_combinations[inds2-4-True])*

------
https://chatgpt.com/codex/tasks/task_e_68a46f50d01c832b826d12e580279832