### PR TITLE
Improve TradingBot logging and resilience

### DIFF
--- a/tests/test_open_short.py
+++ b/tests/test_open_short.py
@@ -21,3 +21,5 @@ def test_open_short(tmp_path):
     assert row[1] == "sell"
     assert float(row[2]) == 100.0
     assert float(row[3]) == expected_qty
+    assert float(row[5]) == 100.0 * (1 - bot.tp_percent / 100)
+    assert float(row[6]) == 100.0 * (1 + bot.sl_percent / 100)


### PR DESCRIPTION
## Summary
- use module-level logger and safe environment parsing helpers
- guard price history and trade logging against I/O errors
- record actual TP/SL values, unify order responses, and close websocket sessions cleanly

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a4721917b0832b8c55f515f43fbd63