### PR TITLE
Refactor trading bot for async reliability

### DIFF
--- a/bybitbot/strategies/ml.py
+++ b/bybitbot/strategies/ml.py
@@ -20,6 +20,11 @@ class MLProbabilityStrategy(ITradingStrategy):
         if self.model is None:
             return None
         prob = self.model.predict_proba(features)[0][1]
+        return self.decide_with_prob(features, price, prob)
+
+    def decide_with_prob(
+        self, features: np.ndarray, price: float, prob: float
+    ) -> str | None:
         if prob > self.long_threshold:
             return "long"
         if prob < self.short_threshold:

--- a/tests/test_position.py
+++ b/tests/test_position.py
@@ -1,3 +1,4 @@
+import asyncio
 import pytest
 
 from bybitbot import TradingBot
@@ -8,22 +9,31 @@ def test_open_short_and_close_position(tmp_path):
 
     bot = TradingBot()
     bot.trade_file = tmp_path / "trades.csv"
-    bot.place_order = lambda side, qty, tp=None, sl=None: {"filledQty": qty}
-    bot.send_telegram = lambda msg: None
+
+    async def fake_place_order(side, qty, tp=None, sl=None):
+        return {"filledQty": qty}
+
+    async def fake_send(msg):
+        pass
+
+    bot.place_order = fake_place_order
+    bot.send_telegram = fake_send
     bot._round_qty = lambda x: x
     bot.trailing_percent = 1.0
     bot.qty_step = 0.01
 
     open_price = 100.0
-    bot.open_short(open_price)
-
-    expected_qty = bot.compute_trade_amount() / open_price
-    assert bot.position_price == open_price
-    assert bot.position_amount == -expected_qty
-    assert bot.trailing_price == pytest.approx(open_price * 1.01)
-
     close_price = 90.0
-    bot.close_position(close_price)
+    expected_qty = bot.compute_trade_amount() / open_price
+
+    async def run() -> None:
+        await bot.open_short(open_price)
+        assert bot.position_price == open_price
+        assert bot.position_amount == -expected_qty
+        assert bot.trailing_price == pytest.approx(open_price * 1.01)
+        await bot.close_position(close_price)
+
+    asyncio.run(run())
 
     assert bot.position_amount == 0
     assert bot.position_price is None

--- a/tests/test_telegram.py
+++ b/tests/test_telegram.py
@@ -1,3 +1,4 @@
+import asyncio
 import logging
 import requests
 
@@ -18,7 +19,7 @@ def test_send_telegram_timeout(monkeypatch, caplog):
     monkeypatch.setattr(requests, "post", fake_post)
 
     with caplog.at_level(logging.WARNING):
-        bot.send_telegram("hi")
+        asyncio.run(bot.send_telegram("hi"))
 
     assert captured["timeout"] == 5
     assert "Telegram send timeout" in caplog.text

--- a/tests/test_trailing.py
+++ b/tests/test_trailing.py
@@ -1,18 +1,29 @@
+import asyncio
+
 from bybitbot import TradingBot
 
 
 def test_handle_trailing_long(tmp_path):
     bot = TradingBot()
     bot.trade_file = tmp_path / "trades.csv"
-    bot.place_order = lambda side, qty, tp=None, sl=None: {"filledQty": qty}
-    bot.send_telegram = lambda msg: None
+
+    async def fake_place_order(side, qty, tp=None, sl=None):
+        return {"filledQty": qty}
+
+    async def fake_send(msg):
+        pass
+
+    bot.place_order = fake_place_order
+    bot.send_telegram = fake_send
     bot.position_price = 100.0
     bot.position_amount = 1.0
     bot.trailing_percent = 1.0
     bot.trailing_price = 99.0
-    # price rises, trailing adjusted
-    assert not bot.handle_trailing(102.0)
-    assert bot.trailing_price == 102.0 * 0.99
-    # price falls, trailing triggers close
-    assert bot.handle_trailing(100.5)
+
+    async def run() -> None:
+        assert not await bot.handle_trailing(102.0)
+        assert bot.trailing_price == 102.0 * 0.99
+        assert await bot.handle_trailing(100.5)
+
+    asyncio.run(run())
     assert bot.position_amount == 0


### PR DESCRIPTION
## Summary
- make order placement and telegram notifications non-blocking
- improve close position error handling and trailing logic
- avoid duplicate probability predictions in trading cycle

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a47dd463c4832b84eaa26878c6aee4