### PR TITLE
Improve order handling and strategy interface

### DIFF
--- a/bybitbot/risk.py
+++ b/bybitbot/risk.py
@@ -22,6 +22,10 @@ class RiskManager:
             self.daily_date = today
             self.daily_pnl = 0.0
 
+    def reset_if_new_day(self) -> None:
+        """Public wrapper to reset PnL counters when day changes."""
+        self._reset_if_new_day()
+
     def can_trade(self) -> bool:
         """Check whether trading is allowed based on daily limits."""
         self._reset_if_new_day()

--- a/bybitbot/strategies/base.py
+++ b/bybitbot/strategies/base.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
+from typing import Any
 import numpy as np
 
 
@@ -11,3 +12,13 @@ class ITradingStrategy(ABC):
     def decide(self, features: np.ndarray, price: float) -> str | None:
         """Return 'long', 'short' or None based on features and current price."""
         raise NotImplementedError
+
+    def set_model(self, model: Any) -> None:  # pragma: no cover - default no-op
+        """Attach an ML model to the strategy if needed."""
+        return None
+
+    def decide_with_prob(
+        self, features: np.ndarray, price: float, prob: float
+    ) -> str | None:
+        """Optional decision hook that also receives model probability."""
+        return self.decide(features, price)


### PR DESCRIPTION
## Summary
- Avoid updating position state when an order fails or fills zero quantity
- Sync last market data during HTTP polling and streamline strategy API
- Provide public risk reset method and narrow exception handling

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a866995778832b875827c60b27542b