### PR TITLE
Harden order placement and model initialization

### DIFF
--- a/bybitbot/bot.py
+++ b/bybitbot/bot.py
@@ -11,7 +11,7 @@ import numpy as np
 
 try:  # pragma: no cover - needed for pandas_ta on NumPy>=2
     from numpy import NaN  # type: ignore  # noqa: F401
-except Exception:  # pragma: no cover
+except (ImportError, AttributeError):  # pragma: no cover
     np.NaN = np.nan
 import pandas as pd
 import pandas_ta as ta
@@ -136,9 +136,7 @@ class TradingBot:
         self.strategy = strategy or MLProbabilityStrategy(
             self.long_threshold, self.short_threshold
         )
-        if hasattr(self.strategy, "set_model"):
-            # type: ignore[call-arg]
-            self.strategy.set_model(self.model)
+        self.strategy.set_model(self.model)
 
     @property
     def indicators(self) -> List[str]:
@@ -189,7 +187,7 @@ class TradingBot:
             info = self.session.get_instruments_info(category="spot", symbol=symbol)
             item = info.get("result", {}).get("list", [{}])[0]
             return item.get("baseCoin", symbol[:-4]), item.get("quoteCoin", symbol[-4:])
-        except Exception:
+        except (requests.RequestException, KeyError, IndexError):
             return symbol[:-4], symbol[-4:]
 
     def _get_qty_step(self) -> float:
@@ -208,7 +206,7 @@ class TradingBot:
             lot = item.get("lotSizeFilter", {})
             step = float(lot.get("qtyStep", 1))
             return step if step > 0 else 1.0
-        except Exception:
+        except (requests.RequestException, KeyError, TypeError, ValueError):
             return 1.0
 
     def _round_qty(self, qty: float) -> float:
@@ -223,7 +221,7 @@ class TradingBot:
                 self.scaler = saved.get("scaler", self.scaler)
                 self.model_initialized = True
                 return
-            except Exception as exc:
+            except (OSError, ValueError) as exc:
                 logger.warning("Failed to load model file: %s", exc)
 
         if self.model_type == "xgb":
@@ -417,6 +415,7 @@ class TradingBot:
         X = np.array(self.features_list)
         y = np.array(self.labels_list)
         Xs = self.scaler.transform(X)
+        trained = False
         try:
             if not self.model_initialized:
                 self.model.fit(Xs, y)
@@ -426,24 +425,26 @@ class TradingBot:
                 )
             elif self.train_counter % self.retrain_interval == 0:
                 self.model.fit(Xs, y)
-        except Exception as exc:
+            trained = True
+        except (ValueError, RuntimeError) as exc:
             logger.warning("Model train error: %s", exc)
-        if len(Xs) and hasattr(self.model, "predict"):
+        if trained:
+            self.model_initialized = True
+        if len(Xs) and hasattr(self.model, "predict") and self.model_initialized:
             try:
                 preds = self.model.predict(Xs)
                 acc = float((preds == y).mean())
                 logger.info("Training accuracy: %.3f", acc)
-            except Exception:
+            except (ValueError, RuntimeError, AttributeError):
                 pass
         self.train_counter += 1
-        if self.train_counter % self.model_save_interval == 0:
+        if self.train_counter % self.model_save_interval == 0 and self.model_initialized:
             try:
                 joblib.dump(
                     {"model": self.model, "scaler": self.scaler}, self.model_file
                 )
-            except Exception as exc:
+            except OSError as exc:
                 logger.warning("Failed to save model: %s", exc)
-        self.model_initialized = True
         latest = self.compute_features(df.iloc[-self.history_len :])
         return self.scaler.transform(latest) if latest is not None else None
 
@@ -463,7 +464,7 @@ class TradingBot:
                     high = float(kitem[2])
                     low = float(kitem[3])
                     volume = float(kitem[5])
-                except Exception:
+                except (requests.RequestException, KeyError, IndexError, ValueError):
                     high = low = price
                     volume = float(
                         ticker.get("volume24h", ticker.get("turnover24h", 0))
@@ -474,7 +475,7 @@ class TradingBot:
                 bid_qty = float(ob["result"]["b"][0][1])
                 ask_qty = float(ob["result"]["a"][0][1])
                 return price, high, low, volume, bid_qty, ask_qty
-            except Exception as exc:
+            except (requests.RequestException, KeyError, IndexError, ValueError) as exc:
                 logger.warning("Market data error: %s", exc)
                 time.sleep(1)
         raise RuntimeError("Failed to fetch market data")
@@ -505,8 +506,9 @@ class TradingBot:
             if avail < needed:
                 logger.warning("Insufficient balance: have %s need %s", avail, needed)
                 return None
-        except Exception as exc:
+        except (requests.RequestException, KeyError, ValueError) as exc:
             logger.warning("Balance check error: %s", exc)
+            return None
 
         for _ in range(self.max_retries):
             try:
@@ -525,6 +527,7 @@ class TradingBot:
                 order = await asyncio.to_thread(self.session.place_order, **params)
                 order_id = order.get("result", {}).get("orderId")
                 filled = qty
+                exec_price = price
                 if order_id:
                     try:
                         status = await asyncio.to_thread(
@@ -535,11 +538,12 @@ class TradingBot:
                         )
                         ord_info = status.get("result", {}).get("list", [{}])[0]
                         filled = float(ord_info.get("cumExecQty", filled))
+                        exec_price = float(ord_info.get("avgPrice", exec_price))
                         logger.info("Order status: %s", ord_info.get("orderStatus"))
-                    except Exception as exc:
+                    except (requests.RequestException, KeyError, ValueError) as exc:
                         logger.warning("Order status error: %s", exc)
-                return {"response": order, "filledQty": filled}
-            except Exception as exc:
+                return {"response": order, "filledQty": filled, "avgPrice": exec_price}
+            except (requests.RequestException, ValueError) as exc:
                 logger.warning("Order error: %s", exc)
                 await asyncio.sleep(1)
         raise RuntimeError("Failed to place order")
@@ -556,14 +560,22 @@ class TradingBot:
         tp_price = price * (1 + self.tp_percent / 100)
         sl_price = price * (1 - self.sl_percent / 100)
         order = await self.place_order("buy", qty, tp=tp_price, sl=sl_price)
-        filled = order.get("filledQty", qty) if order else qty
-        self.position_price = price
+        if not order:
+            return
+        filled = float(order.get("filledQty", 0))
+        if filled <= 0:
+            logger.warning("No quantity filled for long order")
+            return
+        exec_price = float(order.get("avgPrice", price))
+        self.position_price = exec_price
         self.position_amount = filled
         self.trailing_price = (
             price * (1 - self.trailing_percent / 100) if self.trailing_percent else None
         )
-        self.log_trade("buy", price, filled, tp=tp_price, sl=sl_price)
-        await self.send_telegram(f"Opened long {filled:.6f} {self.symbol} @ {price}")
+        self.log_trade("buy", exec_price, filled, tp=tp_price, sl=sl_price)
+        await self.send_telegram(
+            f"Opened long {filled:.6f} {self.symbol} @ {exec_price}"
+        )
 
     async def open_short(self, price: float) -> None:
         if not self.risk_manager.can_trade():
@@ -576,14 +588,22 @@ class TradingBot:
         tp_price = price * (1 - self.tp_percent / 100)
         sl_price = price * (1 + self.sl_percent / 100)
         order = await self.place_order("sell", qty, tp=tp_price, sl=sl_price)
-        filled = order.get("filledQty", qty) if order else qty
-        self.position_price = price
+        if not order:
+            return
+        filled = float(order.get("filledQty", 0))
+        if filled <= 0:
+            logger.warning("No quantity filled for short order")
+            return
+        exec_price = float(order.get("avgPrice", price))
+        self.position_price = exec_price
         self.position_amount = -filled
         self.trailing_price = (
             price * (1 + self.trailing_percent / 100) if self.trailing_percent else None
         )
-        self.log_trade("sell", price, filled, tp=tp_price, sl=sl_price)
-        await self.send_telegram(f"Opened short {filled:.6f} {self.symbol} @ {price}")
+        self.log_trade("sell", exec_price, filled, tp=tp_price, sl=sl_price)
+        await self.send_telegram(
+            f"Opened short {filled:.6f} {self.symbol} @ {exec_price}"
+        )
 
     async def close_position(self, price: float) -> None:
         if self.position_amount == 0:
@@ -592,7 +612,7 @@ class TradingBot:
         qty = abs(self.position_amount)
         try:
             order = await self.place_order(side, qty)
-        except Exception as exc:
+        except (RuntimeError, requests.RequestException) as exc:
             logger.warning("Close position error: %s", exc)
             return
         if not order:
@@ -687,7 +707,7 @@ class TradingBot:
             self._trade_buffer = records
 
     def reset_daily_pnl(self) -> None:
-        self.risk_manager._reset_if_new_day()
+        self.risk_manager.reset_if_new_day()
         self.daily_pnl = self.risk_manager.daily_pnl
         self.daily_date = self.risk_manager.daily_date
 
@@ -754,7 +774,7 @@ class TradingBot:
                         self.last_bid_qty = float(bids[0][1])
                     if asks:
                         self.last_ask_qty = float(asks[0][1])
-                except Exception:
+                except (ValueError, IndexError, TypeError):
                     pass
 
             ws = WebSocket("spot")
@@ -785,17 +805,20 @@ class TradingBot:
                     price, high, low, vol, bid, ask = await asyncio.to_thread(
                         self.get_market_data
                     )
+                    self.last_price = price
+                    self.last_high = high
+                    self.last_low = low
+                    self.last_volume = vol
+                    self.last_bid_qty = bid
+                    self.last_ask_qty = ask
                 features = await asyncio.to_thread(
                     self.update_model, price, high, low, vol, bid, ask
                 )
-                if features is None:
+                if features is None or not self.model_initialized:
                     await asyncio.sleep(self.interval)
                     continue
                 prob = self.model.predict_proba(features)[0][1]
-                if hasattr(self.strategy, "decide_with_prob"):
-                    action = self.strategy.decide_with_prob(features, price, prob)
-                else:
-                    action = self.strategy.decide(features, price)
+                action = self.strategy.decide_with_prob(features, price, prob)
 
                 if self.position_amount > 0:  # long
                     if price >= self.position_price * (
@@ -829,7 +852,7 @@ class TradingBot:
             raise
         except KeyboardInterrupt:
             logger.info("Trading loop interrupted by user")
-        except Exception as exc:
+        except (requests.RequestException, ValueError, RuntimeError) as exc:
             logger.exception("Error in trading loop: %s", exc)
         finally:
             if use_websocket and ws is not None:
@@ -837,5 +860,5 @@ class TradingBot:
                     close = getattr(ws, "close", None) or getattr(ws, "exit", None)
                     if close:
                         close()
-                except Exception as exc:
+                except (RuntimeError, AttributeError) as exc:
                     logger.warning("Failed to close WebSocket: %s", exc)

--- a/bybitbot/risk.py
+++ b/bybitbot/risk.py
@@ -22,6 +22,10 @@ class RiskManager:
             self.daily_date = today
             self.daily_pnl = 0.0
 
+    def reset_if_new_day(self) -> None:
+        """Public wrapper to reset PnL counters when day changes."""
+        self._reset_if_new_day()
+
     def can_trade(self) -> bool:
         """Check whether trading is allowed based on daily limits."""
         self._reset_if_new_day()

--- a/bybitbot/strategies/base.py
+++ b/bybitbot/strategies/base.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
+from typing import Any
 import numpy as np
 
 
@@ -11,3 +12,13 @@ class ITradingStrategy(ABC):
     def decide(self, features: np.ndarray, price: float) -> str | None:
         """Return 'long', 'short' or None based on features and current price."""
         raise NotImplementedError
+
+    def set_model(self, model: Any) -> None:  # pragma: no cover - default no-op
+        """Attach an ML model to the strategy if needed."""
+        return None
+
+    def decide_with_prob(
+        self, features: np.ndarray, price: float, prob: float
+    ) -> str | None:
+        """Optional decision hook that also receives model probability."""
+        return self.decide(features, price)


### PR DESCRIPTION
## Summary
- Prevent market orders when balance checks fail and capture executed price for positions
- Defer model initialization until training succeeds and skip predictions until ready

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a866995778832b875827c60b27542b